### PR TITLE
Hardcode snapshot type as makes no sense to have full for mongo lates…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ This job will start an Mongo Latest cluster running. In order to make the cluste
 
 1. EXPORT_DATE (required) -> the date the data was exported, i.e `2021-04-01`
 1. CORRELATION_ID (required) -> the correlation id for this run, i.e. `generate_snapshots_preprod_generate_full_snapshots_4_full`
-1. SNAPSHOT_TYPE (required) -> either `full` or `incremental` for the type of snapshots for this run
 
 #### Stop clusters
 

--- a/ci/jobs/development/admin/start-cluster.yml
+++ b/ci/jobs/development/admin/start-cluster.yml
@@ -7,5 +7,4 @@ jobs:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
             AWS_ACC: ((aws_account.development))
             CORRELATION_ID: test
-            SNAPSHOT_TYPE: "full"
             EXPORT_DATE: "2020-08-13"

--- a/ci/jobs/integration/admin/start-cluster.yml
+++ b/ci/jobs/integration/admin/start-cluster.yml
@@ -7,5 +7,4 @@ jobs:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.integration)):role/ci
             AWS_ACC: ((aws_account.integration))
             CORRELATION_ID: test
-            SNAPSHOT_TYPE: "full"
             EXPORT_DATE: "2020-08-13"

--- a/ci/jobs/preprod/admin/start-cluster.yml
+++ b/ci/jobs/preprod/admin/start-cluster.yml
@@ -7,5 +7,4 @@ jobs:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci
             AWS_ACC: ((aws_account.preprod))
             CORRELATION_ID: ingest_emr_scheduled_tasks_export_snapshots_to_crown_preprod_incremental_15_incremental
-            SNAPSHOT_TYPE: "full"
             EXPORT_DATE: "2021-05-14"

--- a/ci/jobs/production/admin/start-cluster.yml
+++ b/ci/jobs/production/admin/start-cluster.yml
@@ -7,5 +7,4 @@ jobs:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci
             AWS_ACC: ((aws_account.production))
             CORRELATION_ID: test
-            SNAPSHOT_TYPE: "full"
             EXPORT_DATE: "2020-08-13"

--- a/ci/jobs/qa/admin/start-cluster.yml
+++ b/ci/jobs/qa/admin/start-cluster.yml
@@ -7,5 +7,4 @@ jobs:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci
             AWS_ACC: ((aws_account.qa))
             CORRELATION_ID: test
-            SNAPSHOT_TYPE: "full"
             EXPORT_DATE: "2020-08-13"

--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -184,10 +184,10 @@ meta:
               source /assume-role
               set +x
 
-              jq -n --arg correlation_id "$CORRELATION_ID" --arg snapshot_type "$SNAPSHOT_TYPE" --arg export_date "$EXPORT_DATE" '{
+              jq -n --arg correlation_id "$CORRELATION_ID" --arg export_date "$EXPORT_DATE" '{
                  "correlation_id": $correlation_id,
                  "s3_prefix": "NOT_SET",
-                 "snapshot_type": $snapshot_type,
+                 "snapshot_type": "incremental",
                  "export_date": $export_date
                }' > payload.json
 


### PR DESCRIPTION
Hardcode snapshot type as makes no sense to have full for mongo latest cluster