### PR TITLE
fix mongo-latest pt-1 object-tagger and notification

### DIFF
--- a/cloudwatch-events.tf
+++ b/cloudwatch-events.tf
@@ -302,7 +302,7 @@ resource "aws_cloudwatch_metric_alarm" "mongo_latest_success" {
   insufficient_data_actions = []
   alarm_actions             = [data.terraform_remote_state.security-tools.outputs.sns_topic_london_monitoring.arn]
   dimensions = {
-    RuleName = aws_cloudwatch_event_rule.mongo_latest_success.name
+    RuleName = aws_cloudwatch_event_rule.pt_minus_1_success.name
   }
   tags = merge(
     local.common_tags,

--- a/cloudwatch-events.tf
+++ b/cloudwatch-events.tf
@@ -324,7 +324,7 @@ resource "aws_cloudwatch_metric_alarm" "pt_minus_1_success" {
   period                    = "60"
   statistic                 = "Sum"
   threshold                 = "1"
-  alarm_description         = "Monitoring Mongo Latest completion"
+  alarm_description         = "Monitoring PT-1 completion"
   insufficient_data_actions = []
   alarm_actions             = [data.terraform_remote_state.security-tools.outputs.sns_topic_london_monitoring.arn]
   dimensions = {

--- a/cloudwatch-events.tf
+++ b/cloudwatch-events.tf
@@ -72,6 +72,28 @@ resource "aws_cloudwatch_event_rule" "mongo_latest_success" {
 }
 EOF
 }
+resource "aws_cloudwatch_event_rule" "pt_minus_1_success" {
+  name          = "pt_minus_1_success"
+  description   = "checks that all steps complete"
+  event_pattern = <<EOF
+{
+  "source": [
+    "aws.emr"
+  ],
+  "detail-type": [
+    "EMR Step Status Change"
+  ],
+  "detail": {
+    "state": [
+      "COMPLETED"
+    ],
+    "name": [
+      "mongo-latest"
+    ]
+  }
+}
+EOF
+}
 
 resource "aws_cloudwatch_event_rule" "mongo_latest_success_with_errors" {
   name          = "mongo_latest_success_with_errors"

--- a/cloudwatch-events.tf
+++ b/cloudwatch-events.tf
@@ -302,12 +302,38 @@ resource "aws_cloudwatch_metric_alarm" "mongo_latest_success" {
   insufficient_data_actions = []
   alarm_actions             = [data.terraform_remote_state.security-tools.outputs.sns_topic_london_monitoring.arn]
   dimensions = {
-    RuleName = aws_cloudwatch_event_rule.pt_minus_1_success.name
+    RuleName = aws_cloudwatch_event_rule.mongo_latest_success.name
   }
   tags = merge(
     local.common_tags,
     {
       Name              = "mongo_latest_success",
+      notification_type = "Information",
+      severity          = "Critical"
+    },
+  )
+}
+
+resource "aws_cloudwatch_metric_alarm" "pt_minus_1_success" {
+  count                     = local.mongo_latest_alerts[local.environment] == true ? 1 : 0
+  alarm_name                = "pt_minus_1_success"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "TriggeredRules"
+  namespace                 = "AWS/Events"
+  period                    = "60"
+  statistic                 = "Sum"
+  threshold                 = "1"
+  alarm_description         = "Monitoring Mongo Latest completion"
+  insufficient_data_actions = []
+  alarm_actions             = [data.terraform_remote_state.security-tools.outputs.sns_topic_london_monitoring.arn]
+  dimensions = {
+    RuleName = aws_cloudwatch_event_rule.pt_minus_1_success.name
+  }
+  tags = merge(
+    local.common_tags,
+    {
+      Name              = "pt_minus_1_success",
       notification_type = "Information",
       severity          = "Critical"
     },

--- a/cloudwatch-events.tf
+++ b/cloudwatch-events.tf
@@ -88,7 +88,7 @@ resource "aws_cloudwatch_event_rule" "pt_minus_1_success" {
       "COMPLETED"
     ],
     "name": [
-      "mongo-latest"
+      "pt-minus-1-sql"
     ]
   }
 }

--- a/object_tagging.tf
+++ b/object_tagging.tf
@@ -48,19 +48,6 @@ resource "aws_iam_role_policy_attachment" "allow_batch_job_submission" {
   policy_arn = aws_iam_policy.allow_batch_job_submission.arn
 }
 
-resource "aws_cloudwatch_event_target" "mongo_latest_success_start_object_tagger" {
-  target_id = "mongo_latest_success"
-  rule      = aws_cloudwatch_event_rule.mongo_latest_success.name
-  arn       = data.terraform_remote_state.aws_s3_object_tagger.outputs.s3_object_tagger_batch.pt_job_queue.arn
-  role_arn  = aws_iam_role.allow_batch_job_submission.arn
-
-  batch_target {
-    job_definition = data.terraform_remote_state.aws_s3_object_tagger.outputs.s3_object_tagger_batch.job_definition.name
-    job_name       = "mongo-latest-success-cloudwatch-event"
-  }
-
-  input = "{\"Parameters\": {\"data-s3-prefix\": \"${local.data_classification.data_s3_prefix}\", \"csv-location\": \"s3://${local.data_classification.config_bucket.id}/${local.data_classification.config_prefix}/data_classification.csv\"}}"
-}
 resource "aws_cloudwatch_event_target" "pt_minus_1_success_start_object_tagger" {
   target_id = "pt_minus_1_success"
   rule      = aws_cloudwatch_event_rule.pt_minus_1_success.name

--- a/object_tagging.tf
+++ b/object_tagging.tf
@@ -61,3 +61,16 @@ resource "aws_cloudwatch_event_target" "mongo_latest_success_start_object_tagger
 
   input = "{\"Parameters\": {\"data-s3-prefix\": \"${local.data_classification.data_s3_prefix}\", \"csv-location\": \"s3://${local.data_classification.config_bucket.id}/${local.data_classification.config_prefix}/data_classification.csv\"}}"
 }
+resource "aws_cloudwatch_event_target" "pt_minus_1_success_start_object_tagger" {
+  target_id = "pt_minus_1_success"
+  rule      = aws_cloudwatch_event_rule.pt_minus_1_success.name
+  arn       = data.terraform_remote_state.aws_s3_object_tagger.outputs.s3_object_tagger_batch.pt_job_queue.arn
+  role_arn  = aws_iam_role.allow_batch_job_submission.arn
+
+  batch_target {
+    job_definition = data.terraform_remote_state.aws_s3_object_tagger.outputs.s3_object_tagger_batch.job_definition.name
+    job_name       = "mongo-latest-success-cloudwatch-event"
+  }
+
+  input = "{\"Parameters\": {\"data-s3-prefix\": \"${local.data_classification.data_s3_prefix}\", \"csv-location\": \"s3://${local.data_classification.config_bucket.id}/${local.data_classification.config_prefix}/data_classification.csv\"}}"
+}

--- a/object_tagging.tf
+++ b/object_tagging.tf
@@ -69,7 +69,7 @@ resource "aws_cloudwatch_event_target" "pt_minus_1_success_start_object_tagger" 
 
   batch_target {
     job_definition = data.terraform_remote_state.aws_s3_object_tagger.outputs.s3_object_tagger_batch.job_definition.name
-    job_name       = "mongo-latest-success-cloudwatch-event"
+    job_name       = "pt-minus-1-success-cloudwatch-event"
   }
 
   input = "{\"Parameters\": {\"data-s3-prefix\": \"${local.data_classification.data_s3_prefix}\", \"csv-location\": \"s3://${local.data_classification.config_bucket.id}/${local.data_classification.config_prefix}/data_classification.csv\"}}"


### PR DESCRIPTION
- creates new cw event rule for pt-1
- maps object-tagger to this new cw event rule
- removes existing object-tagger as target for `mongo_latest_success` cw rule
- adds new cw alarm for pt-1 to receive slack alerts.